### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ share-img: /assets/img/gsc_logo_sml.png
 ---
 <!--{% include carousel.html height="50" unit="%" duration="5" %}-->
 
-<h2> GSC24 Tuscon</h2>
+<h2> GSC24 Tucson</h2>
 
 <p>The GSC 2024 annual meeting will be located at the University of Arizona’s Bio5 facility. The GSC24 meeting will focus on Challenges of Reproducibility in Genomics with sessions for Standards in Genomic Reproducibility, Virome standards, IMMSA: A year long discussion on data reuse, Genomics and Standards challenges at UofA, Omics Standards including genomic standards pertinent to pathogens, GA4GH experimental data, proteomics and eDNA and concluding with the Discussion of Challenges to Solutions session. 
 Afternoon Working Groups will include CIG - MIxS standards, GA4GH experimental metadata hackathon, TDWG - CIG interactions, NMDC Field Notes mobile app workshop.</p>


### PR DESCRIPTION
"Tucson" is incorrectly spelled Tuscon. It happens often. The correct spelling is Tucson.